### PR TITLE
Support new extended duration format

### DIFF
--- a/src/promql.grammar
+++ b/src/promql.grammar
@@ -239,7 +239,8 @@ MetricIdentifier {
     "`" ![`]* "`"
   }
 
-  Duration { std.digit+ ("s" | "m" | "h" | "d" | "w" | "y")}
+  // TODO: Use external tokenizer for durations to ensure that units are ordered from longest to shortest.
+  Duration { ( std.digit+ ("ms" | "s" | "m" | "h" | "d" | "w" | "y") )+ }
   Identifier { (std.asciiLetter | "_" | ":") (std.asciiLetter | std.digit | "_" | ":" )*}
   LabelName { (std.asciiLetter | "_") (std.asciiLetter | std.digit | "_")* }
 

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -308,3 +308,11 @@ Expr(
     )
   )
 )
+
+# Duration units
+
+foo[1y2m3d4h5m6s7ms]
+
+==>
+
+Expr(MatrixSelector(Expr(VectorSelector(MetricIdentifier(Identifier))),Duration))


### PR DESCRIPTION
See https://github.com/prometheus/prometheus/pull/7713

`0` (without a unit) is actually only supported in the configuration files, not in PromQL itself, thus it's not included in the token regex here.

Signed-off-by: Julius Volz <julius.volz@gmail.com>