### PR TITLE
remove unecessary case for the FunctionCallArgs

### DIFF
--- a/src/promql.grammar
+++ b/src/promql.grammar
@@ -168,8 +168,7 @@ FunctionCallBody {
 
 FunctionCallArgs {
   FunctionCallArgs "," Expr |
-  Expr |
-  FunctionCallArgs ","
+  Expr
 }
 
 ParenExpr {


### PR DESCRIPTION
Signed-off-by: Augustin Husson <husson.augustin@gmail.com>