### PR TITLE
Simplify grammar around binary operator modifiers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lezer-promql",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/promql.grammar
+++ b/src/promql.grammar
@@ -50,46 +50,37 @@ AggregateModifier {
 }
 
 BinaryExpr {
-  Expr !pow Pow        BinModifier Expr |
-  Expr !mul Mul        BinModifier Expr |
-  Expr !mul Div        BinModifier Expr |
-  Expr !mul Mod        BinModifier Expr |
-  Expr !add Add        BinModifier Expr |
-  Expr !add Sub        BinModifier Expr |
-  Expr !eql Eql        BinModifier Expr |
-  Expr !eql Gte        BinModifier Expr |
-  Expr !eql Gtr        BinModifier Expr |
-  Expr !eql Lte        BinModifier Expr |
-  Expr !eql Lss        BinModifier Expr |
-  Expr !eql Neq        BinModifier Expr |
-  Expr !and And        BinModifier Expr |
-  Expr !and Unless     BinModifier Expr |
-  Expr !or  Or         BinModifier Expr
-}
-
-BinModifier {
-  GroupModifiers
-}
-
-BoolModifier {
-  "" |
-  Bool
+  Expr !pow Pow    BinModifiers Expr |
+  Expr !mul Mul    BinModifiers Expr |
+  Expr !mul Div    BinModifiers Expr |
+  Expr !mul Mod    BinModifiers Expr |
+  Expr !add Add    BinModifiers Expr |
+  Expr !add Sub    BinModifiers Expr |
+  Expr !eql Eql    BinModifiers Expr |
+  Expr !eql Gte    BinModifiers Expr |
+  Expr !eql Gtr    BinModifiers Expr |
+  Expr !eql Lte    BinModifiers Expr |
+  Expr !eql Lss    BinModifiers Expr |
+  Expr !eql Neq    BinModifiers Expr |
+  Expr !and And    BinModifiers Expr |
+  Expr !and Unless BinModifiers Expr |
+  Expr !or  Or     BinModifiers Expr
 }
 
 OnOrIgnoring {
-  BoolModifier Ignoring GroupingLabels |
-  BoolModifier On GroupingLabels
+  Ignoring GroupingLabels |
+  On GroupingLabels
 }
 
-GroupModifiers {
-  BoolModifier |
-  OnOrIgnoring |
-  OnOrIgnoring GroupLeft MaybeGroupingLabels |
-  OnOrIgnoring GroupRight MaybeGroupingLabels
-}
-
-MaybeGroupingLabels {
-  "" | !mul GroupingLabels // TODO: Is the "!mul" here correct? Inserted it to resolve a shift/reduce conflict.
+BinModifiers {
+  Bool?
+  (
+    OnOrIgnoring
+    (
+      (GroupLeft | GroupRight)
+      (!mul GroupingLabels)? // TODO: Is the "!mul" here correct? Inserted it to resolve a shift/reduce conflict.
+    )?
+  )?
 }
 
 GroupingLabels {

--- a/src/promql.grammar
+++ b/src/promql.grammar
@@ -78,7 +78,7 @@ BinModifiers {
     OnOrIgnoring
     (
       (GroupLeft | GroupRight)
-      (!mul GroupingLabels)? // TODO: Is the "!mul" here correct? Inserted it to resolve a shift/reduce conflict.
+      (!mul GroupingLabels)? // TODO: Is the "!mul" here correct? Inserted it to resolve a shift/reduce conflict because we always want to count opening parenthesis after this to be counted toward this modifier, not toward a next sub-expression.
     )?
   )?
 }

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -46,7 +46,7 @@ PromQL(Expr(StringLiteral))
 
 ==>
 
-PromQL(Expr(BinaryExpr(Expr(NumberLiteral), Add, BoolModifier, BinModifier(GroupModifiers), Expr(NumberLiteral))))
+PromQL(Expr(BinaryExpr(Expr(NumberLiteral), Add, BinModifiers, Expr(NumberLiteral))))
 
 # Complex expression
 
@@ -99,20 +99,16 @@ PromQL(
         )
       ),
       Div,
-      BoolModifier,
-      BinModifier(
-        GroupModifiers(
-          OnOrIgnoring(
-            On,
-            GroupingLabels(
-              GroupingLabelList(
-                GroupingLabel(LabelName)
-              )
+      BinModifiers(
+        OnOrIgnoring(
+          On,
+          GroupingLabels(
+            GroupingLabelList(
+              GroupingLabel(LabelName)
             )
-          ),
-          GroupLeft,
-          MaybeGroupingLabels
-        )
+          )
+        ),
+        GroupLeft
       ),
       Expr(
         AggregateExpr(
@@ -188,15 +184,12 @@ PromQL(
         )
       ),
       Div,
-      BoolModifier,
-      BinModifier(
-        GroupModifiers(
-          OnOrIgnoring(
-            Ignoring,
-            GroupingLabels(
-              GroupingLabelList(
-                GroupingLabel(LabelName)
-              )
+      BinModifiers(
+        OnOrIgnoring(
+          Ignoring,
+          GroupingLabels(
+            GroupingLabelList(
+              GroupingLabel(LabelName)
             )
           )
         )
@@ -254,8 +247,7 @@ PromQL(
                             )
                           ),
                           And,
-                          BoolModifier,
-                          BinModifier(GroupModifiers),
+                          BinModifiers,
                           Expr(
                             VectorSelector(
                               MetricIdentifier(Identifier)
@@ -264,8 +256,7 @@ PromQL(
                         )
                       ),
                       And,
-                      BoolModifier,
-                      BinModifier(GroupModifiers),
+                      BinModifiers,
                       Expr(
                         VectorSelector(
                           MetricIdentifier(Identifier)
@@ -274,8 +265,7 @@ PromQL(
                     )
                   ),
                   Unless,
-                  BoolModifier,
-                  BinModifier(GroupModifiers),
+                  BinModifiers,
                   Expr(
                     VectorSelector(
                       MetricIdentifier(Identifier)
@@ -284,8 +274,7 @@ PromQL(
                 )
               ),
               Unless,
-              BoolModifier,
-              BinModifier(GroupModifiers),
+              BinModifiers,
               Expr(
                 VectorSelector(
                   MetricIdentifier(Identifier)
@@ -294,8 +283,7 @@ PromQL(
             )
           ),
           Or,
-          BoolModifier,
-          BinModifier(GroupModifiers),
+          BinModifiers,
           Expr(
             VectorSelector(
               MetricIdentifier(Identifier)
@@ -304,8 +292,7 @@ PromQL(
         )
       ),
       Or,
-      BoolModifier,
-      BinModifier(GroupModifiers),
+      BinModifiers,
       Expr(
         VectorSelector(
           MetricIdentifier(Identifier)
@@ -377,6 +364,72 @@ PromQL(
             StringLiteral
           )
         ),
+      )
+    )
+  )
+)
+
+# Binary expression with bool modifier
+
+metric_name > bool 1
+
+==>
+
+PromQL(
+  Expr(
+    BinaryExpr(
+      Expr(
+        VectorSelector(
+          MetricIdentifier(Identifier)
+        )
+      ),
+      Gtr,
+      BinModifiers(Bool),
+      Expr(NumberLiteral)
+    )
+  )
+)
+
+# Binary expression with group_x() labels.
+
+metric1 + on(foo) group_left(bar, baz) metric2
+
+==>
+
+PromQL(
+  Expr(
+    BinaryExpr(
+      Expr(
+        VectorSelector(
+          MetricIdentifier(Identifier)
+        )
+      ),
+      Add,
+      BinModifiers(
+        OnOrIgnoring(
+          On,
+          GroupingLabels(
+            GroupingLabelList(
+              GroupingLabel(LabelName)
+            )
+          )
+        ),
+        GroupLeft,
+        GroupingLabels(
+          GroupingLabelList(
+            GroupingLabelList(
+              GroupingLabel(LabelName)
+            ),
+            GroupingLabel(LabelName)
+          )
+        )
+      ),
+      Expr(
+        VectorSelector(
+          MetricIdentifier(
+            Identifier
+          )
+        )
       )
     )
   )


### PR DESCRIPTION
The Prometheus PromQL parser inserts an intermediate 1:1 rule that we
copied initially, but that we probably don't need:

https://github.com/prometheus/prometheus/blob/511511324adfc4f4178f064cc104c2deac3335de/promql/parser/generated_parser.y#L247-L249

Also, defining BoolModifier as either an empty string or "bool" caused
lezer to put a BoolModifier token in places where it shouldn't be
grammatically allowed, so now just defined it as an optional "bool"
string instead.

Signed-off-by: Julius Volz <julius.volz@gmail.com>