### PR TITLE
fix parsing metric beginning by inf/nan

### DIFF
--- a/src/promql.grammar
+++ b/src/promql.grammar
@@ -198,7 +198,7 @@ SubqueryExpr {
 }
 
 UnaryExpr {
-  !mul UnaryOp Expr
+  !mul UnaryOp~statement Expr
 }
 
 UnaryOp {
@@ -239,15 +239,15 @@ MetricIdentifier {
 }
 
 StepInvariantExpr {
-  Expr At ( NumberLiteral | SignedNumber | AtModifierPreprocessors "(" ")" )
+  Expr At ( NumberLiteral | AtModifierPreprocessors "(" ")" )
 }
 
 AtModifierPreprocessors {
   Start | End
 }
 
-SignedNumber{
-  ("+" | "-" ) NumberLiteral
+NumberLiteral  {
+ ("-"|"+")?~statement (digit | inf | nan)
 }
 
 @skip { whitespace | LineComment }
@@ -256,13 +256,9 @@ SignedNumber{
   whitespace { std.whitespace+ }
   LineComment { "#" ![\n]* }
 
-  NumberLiteral {
-    ("+" | "-")? (
+  digit {
       (std.digit+ ("." std.digit*)? | "." std.digit+) (("e" | "E") ("+" | "-")? std.digit+)? |
-      "0x" (std.digit | $[a-fA-F])+ |
-      $[nN]$[aA]$[nN] |
-      $[iI]$[nN]$[fF]
-    )
+      "0x" (std.digit | $[a-fA-F])+
   }
   StringLiteral { // TODO: This is for JS, make this work for PromQL.
     '"' (![\\\n"] | "\\" _)* '"'? |
@@ -303,20 +299,13 @@ SignedNumber{
 
   // Special Modifier
   At { "@" }
-
-  // Modifier Preprocessors
-  Start { "start" }
-  End { "end" }
-
-  // To parse signed numbers into a number literal and not a unary expression.
-  @precedence { NumberLiteral, "+", "-" }
-  // To parse NaN/Inf as a number literal.
-  @precedence { NumberLiteral, Identifier }
 }
 
 // Keywords
 
 @external specialize {Identifier} specializeIdentifier from "./tokens" {
+  inf,
+  nan,
   Bool,
   Ignoring,
   On,
@@ -344,7 +333,9 @@ SignedNumber{
   Without,
   And,
   Or,
-  Unless
+  Unless,
+  Start,
+  End
 }
 
   // FunctionIdentifier definitions

--- a/src/promql.grammar
+++ b/src/promql.grammar
@@ -198,7 +198,7 @@ SubqueryExpr {
 }
 
 UnaryExpr {
-  !mul UnaryOp~statement Expr
+  !mul UnaryOp~signed Expr
 }
 
 UnaryOp {
@@ -247,7 +247,7 @@ AtModifierPreprocessors {
 }
 
 NumberLiteral  {
- ("-"|"+")?~statement (digit | inf | nan)
+ ("-"|"+")?~signed (number | inf | nan)
 }
 
 @skip { whitespace | LineComment }
@@ -256,7 +256,7 @@ NumberLiteral  {
   whitespace { std.whitespace+ }
   LineComment { "#" ![\n]* }
 
-  digit {
+  number {
       (std.digit+ ("." std.digit*)? | "." std.digit+) (("e" | "E") ("+" | "-")? std.digit+)? |
       "0x" (std.digit | $[a-fA-F])+
   }

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -12,9 +12,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Bool, Ignoring, On, GroupLeft, GroupRight, Offset, Avg, Bottomk, Count, CountValues, Group, Max, Min, Quantile, Stddev, Stdvar, Sum, Topk, By, Without, And, Or, Unless} from './parser.terms.js';
+import {
+    And,
+    Avg,
+    Bool,
+    Bottomk,
+    By,
+    Count,
+    CountValues,
+    End,
+    Group,
+    GroupLeft,
+    GroupRight,
+    Ignoring,
+    inf,
+    Max,
+    Min,
+    nan,
+    Offset,
+    On,
+    Or,
+    Quantile,
+    Start,
+    Stddev,
+    Stdvar,
+    Sum,
+    Topk,
+    Unless,
+    Without,
+} from './parser.terms.js';
 
 const keywordTokens = {
+  inf: inf,
+  nan: nan,
   bool: Bool,
   ignoring: Ignoring,
   on: On,
@@ -45,6 +75,8 @@ const contextualKeywordTokens = {
   and: And,
   or: Or,
   unless: Unless,
+  start: Start,
+  end: End,
 }
 
 export const extendIdentifier = (value, stack) => {

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -518,6 +518,20 @@ PromQL(
   )
 )
 
+# Metric start
+
+start
+
+==>
+PromQL(Expr(VectorSelector(MetricIdentifier(Identifier))))
+
+# Metric end
+
+end
+
+==>
+PromQL(Expr(VectorSelector(MetricIdentifier(Identifier))))
+
 # Simple At start
 
 foo @ start()
@@ -682,7 +696,7 @@ PromQL(
         )
       )
       At,
-      SignedNumber(NumberLiteral)
+      NumberLiteral
     )
   )
 )
@@ -703,10 +717,24 @@ PromQL(
         )
       )
       At,
-      SignedNumber(NumberLiteral)
+      NumberLiteral
     )
   )
 )
+
+# Metric prefixed by Inf
+
+infra
+
+==>
+PromQL(Expr(VectorSelector(MetricIdentifier(Identifier))))
+
+# Metric prefixed by Nan
+
+nananere
+
+==>
+PromQL(Expr(VectorSelector(MetricIdentifier(Identifier))))
 
 # Mixed-case NaN.
 
@@ -732,6 +760,13 @@ PromQL(Expr(NumberLiteral))
 # Negative Inf.
 
 -Inf
+
+==>
+PromQL(Expr(NumberLiteral))
+
+# Positive Inf.
+
++Inf
 
 ==>
 PromQL(Expr(NumberLiteral))


### PR DESCRIPTION
So I think I made a good progress to fix #33.

The last thing that bugs me is why lezer is considering `+inf` as an `Unary` expression and not as a `NumberLiteral` which is the case without the sign ...

I think I'm quite closed, just a tweak to find how to manage properly the sign. And I thing once it is fixed, it would also fix #29 

What do you think @juliusv ?