### PR TITLE
introduced the optional dialects variables

### DIFF
--- a/src/promql.grammar
+++ b/src/promql.grammar
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@dialects { variables }
+
 @top PromQL { Expr }
 
 @precedence {
@@ -56,7 +58,8 @@ AggregateOp {
   Stddev |
   Stdvar |
   Sum |
-  Topk
+  Topk |
+  Variable~ambig-variable
 }
 
 AggregateModifier {
@@ -167,7 +170,8 @@ FunctionIdentifier {
   Timestamp |
   Time |
   Vector |
-  Year
+  Year |
+  Variable~ambig-variable
 }
 
 FunctionCallBody {
@@ -246,15 +250,23 @@ AtModifierPreprocessors {
   Start | End
 }
 
-NumberLiteral  {
- ("-"|"+")?~signed (number | inf | nan)
+NumberLiteral {
+ ("-"|"+")?~signed (number | inf | nan | Variable~ambig-variable)
 }
+
+Identifier { identifier | Variable~ambig-variable }
+
+LabelName { labelName | Variable }
 
 @skip { whitespace | LineComment }
 
 @tokens {
   whitespace { std.whitespace+ }
   LineComment { "#" ![\n]* }
+
+  Variable[@dialect=variables] {
+    "${" (std.digit | std.asciiLetter | "-" | "_")+ "}"
+  }
 
   number {
       (std.digit+ ("." std.digit*)? | "." std.digit+) (("e" | "E") ("+" | "-")? std.digit+)? |
@@ -277,8 +289,8 @@ NumberLiteral  {
     ( ( std.digit+ "y" )? ( std.digit+ "w" )? ( std.digit+ "d" )? ( std.digit+ "h" )? ( std.digit+ "m" )? ( std.digit+ "s" ) ( std.digit+ "ms" )? ) |
     ( ( std.digit+ "y" )? ( std.digit+ "w" )? ( std.digit+ "d" )? ( std.digit+ "h" )? ( std.digit+ "m" )? ( std.digit+ "s" )? ( std.digit+ "ms" ) )
   }
-  Identifier { (std.asciiLetter | "_" | ":") (std.asciiLetter | std.digit | "_" | ":" )*}
-  LabelName { (std.asciiLetter | "_") (std.asciiLetter | std.digit | "_")* }
+  identifier { (std.asciiLetter | "_" | ":") (std.asciiLetter | std.digit | "_" | ":" )*}
+  labelName { (std.asciiLetter | "_") (std.asciiLetter | std.digit | "_")* }
 
   // Operator
   Sub { "-" }
@@ -303,7 +315,7 @@ NumberLiteral  {
 
 // Keywords
 
-@external specialize {Identifier} specializeIdentifier from "./tokens" {
+@external specialize {identifier} specializeIdentifier from "./tokens" {
   inf,
   nan,
   Bool,
@@ -316,7 +328,7 @@ NumberLiteral  {
 
 // Contextual keywords
 
-@external extend {Identifier} extendIdentifier from "./tokens" {
+@external extend {identifier} extendIdentifier from "./tokens" {
   Avg,
   Bottomk,
   Count,
@@ -391,4 +403,4 @@ NumberLiteral  {
   Year { condFn<"year"> }
 
 // Conditional function names (only parsed as function names when used as such).
-condFn<term> { @extend<Identifier, term> }
+condFn<term> { @extend<identifier, term> }

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -833,3 +833,62 @@ foo offset 5d
 
 ==>
 PromQL(Expr(OffsetExpr(Expr(VectorSelector(MetricIdentifier(Identifier))), Offset, Duration)))
+
+# Simple variable
+
+${foo}
+
+==>
+PromQL(Expr(VectorSelector(MetricIdentifier(Identifier(Variable)))))
+
+# Variable as an aggregation
+
+${myAggregation} by(l1) (foo)
+
+==>
+PromQL(Expr(AggregateExpr(AggregateOp(Variable),AggregateModifier(By,GroupingLabels(GroupingLabelList(GroupingLabel(LabelName)))),FunctionCallBody(FunctionCallArgs(Expr(VectorSelector(MetricIdentifier(Identifier))))))))
+
+# Operation with variable
+
+${foo} + ${MyHiddenNumber}
+
+==>
+PromQL(Expr(BinaryExpr(Expr(VectorSelector(MetricIdentifier(Identifier(Variable)))),Add,BinModifiers,Expr(VectorSelector(MetricIdentifier(Identifier(Variable)))))))
+
+# Variable as a label
+
+sum by(${l1}) (rate(metric{${l1}="value"}[5d]))
+
+==>
+PromQL(
+  Expr(
+    AggregateExpr(
+      AggregateOp(Sum),
+      AggregateModifier(By,GroupingLabels(GroupingLabelList(GroupingLabel(LabelName(Variable))))),
+      FunctionCallBody(
+        FunctionCallArgs(
+          Expr(
+            FunctionCall(
+              FunctionIdentifier(Rate),
+              FunctionCallBody(
+                FunctionCallArgs(
+                  Expr(
+                    MatrixSelector(
+                      Expr(
+                        VectorSelector(
+                          MetricIdentifier(Identifier),
+                          LabelMatchers(LabelMatchList(LabelMatcher(LabelName(Variable),MatchOp(EqlSingle),StringLiteral)))
+                        )
+                      ),
+                      Duration
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/test/test-promql.js
+++ b/test/test-promql.js
@@ -12,6 +12,6 @@ for (let file of fs.readdirSync(caseDir)) {
   let name = /^[^\.]*/.exec(file)[0]
   describe(name, () => {
     for (let {name, run} of fileTests(fs.readFileSync(path.join(caseDir, file), "utf8"), file))
-      it(name, () => run(parser))
+      it(name, () => run(parser.configure({dialect:'variables'})))
   })
 }


### PR DESCRIPTION
Signed-off-by: Augustin Husson <husson.augustin@gmail.com>

Should help for the issue https://github.com/prometheus-community/codemirror-promql/issues/138

With this PR we can use the variable a bit everywhere. I maybe miss some scenarios.

The biggest issue I'm seing with this new dialect is that the linter won't be accurate anymore.

Specially for cases like `${foo} + bool ${bar}`. As it is possible that the variable `${bar}` is a number, then the syntax is valid for the moment.
But perhaps the simple way is to deactivate the linter when this dialect is activated.