### PR TITLE
Add missing functions

### DIFF
--- a/src/promql.grammar
+++ b/src/promql.grammar
@@ -122,16 +122,25 @@ FunctionIdentifier {
   AbsentOverTime |
   Absent |
   Abs |
+  Acos |
+  Acosh |
+  Asin |
+  Asinh |
+  Atan |
+  Atanh |
   AvgOverTime |
   Ceil |
   Changes |
   Clamp |
   ClampMax |
   ClampMin |
+  Cos |
+  Cosh |
   CountOverTime |
   DaysInMonth |
   DayOfMonth |
   DayOfWeek |
+  Deg |
   Delta |
   Deriv |
   Exp |
@@ -152,20 +161,26 @@ FunctionIdentifier {
   MinOverTime |
   Minute |
   Month |
+  Pi |
   PredictLinear |
   PresentOverTime |
   QuantileOverTime |
+  Rad |
   Rate |
   Resets |
   Round |
   Scalar |
   Sgn |
+  Sin |
+  Sinh |
   Sort |
   SortDesc |
   Sqrt |
   StddevOverTime |
   StdvarOverTime |
   SumOverTime |
+  Tan |
+  Tanh |
   Timestamp |
   Time |
   Vector |
@@ -344,16 +359,25 @@ NumberLiteral  {
   Abs { condFn<"abs"> }
   Absent { condFn<"absent"> }
   AbsentOverTime { condFn<"absent_over_time"> }
+  Acos { condFn<"acos"> }
+  Acosh { condFn<"acosh"> }
+  Asin { condFn<"asin"> }
+  Asinh { condFn<"asinh"> }
+  Atan { condFn<"atan"> }
+  Atanh { condFn<"atanh"> }
   AvgOverTime { condFn<"avg_over_time"> }
   Ceil { condFn<"ceil"> }
   Changes { condFn<"changes"> }
   Clamp { condFn<"clamp"> }
   ClampMax { condFn<"clamp_max"> }
   ClampMin { condFn<"clamp_min"> }
+  Cos { condFn<"cos"> }
+  Cosh { condFn<"cosh"> }
   CountOverTime { condFn<"count_over_time"> }
   DaysInMonth { condFn<"days_in_month"> }
   DayOfMonth { condFn<"day_of_month"> }
   DayOfWeek { condFn<"day_of_week"> }
+  Deg { condFn<"deg"> }
   Delta { condFn<"delta"> }
   Deriv { condFn<"deriv"> }
   Exp { condFn<"exp"> }
@@ -374,20 +398,26 @@ NumberLiteral  {
   MinOverTime { condFn<"min_over_time"> }
   Minute { condFn<"minute"> }
   Month { condFn<"month"> }
+  Pi { condFn<"pi"> }
   PredictLinear { condFn<"predict_linear"> }
   PresentOverTime { condFn<"present_over_time"> }
   QuantileOverTime { condFn<"quantile_over_time"> }
+  Rad { condFn<"rad"> }
   Rate { condFn<"rate"> }
   Resets { condFn<"resets"> }
   Round { condFn<"round"> }
   Scalar { condFn<"scalar"> }
   Sgn { condFn<"sgn"> }
+  Sin { condFn<"sin"> }
+  Sinh { condFn<"sinh"> }
   Sort { condFn<"sort"> }
   SortDesc { condFn<"sort_desc"> }
   Sqrt { condFn<"sqrt"> }
   StddevOverTime { condFn<"stddev_over_time"> }
   StdvarOverTime { condFn<"stdvar_over_time"> }
   SumOverTime { condFn<"sum_over_time"> }
+  Tan { condFn<"tan"> }
+  Tanh { condFn<"tanh"> }
   Time { condFn<"time"> }
   Timestamp { condFn<"timestamp"> }
   Vector { condFn<"vector"> }

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -363,7 +363,7 @@ PromQL(
             MatchOp(NeqRegex),
             StringLiteral
           )
-        ),
+        )
       )
     )
   )
@@ -546,9 +546,9 @@ PromQL(
             Identifier
           )
         )
-      )
+      ),
       At,
-      AtModifierPreprocessors(Start),
+      AtModifierPreprocessors(Start)
     )
   )
 )
@@ -567,9 +567,9 @@ PromQL(
             Identifier
           )
         )
-      )
+      ),
       At,
-      AtModifierPreprocessors(End),
+      AtModifierPreprocessors(End)
     )
   )
 )
@@ -588,7 +588,7 @@ PromQL(
             Identifier
           )
         )
-      )
+      ),
       At,
       NumberLiteral
     )
@@ -609,9 +609,9 @@ PromQL(
             Identifier
           )
         )
-      )
+      ),
       At,
-      AtModifierPreprocessors(Start),
+      AtModifierPreprocessors(Start)
     )
   )
 )
@@ -694,7 +694,7 @@ PromQL(
             Identifier
           )
         )
-      )
+      ),
       At,
       NumberLiteral
     )
@@ -715,7 +715,7 @@ PromQL(
             Identifier
           )
         )
-      )
+      ),
       At,
       NumberLiteral
     )
@@ -840,3 +840,10 @@ sum:my_metric_name:rate5m
 
 ==>
 MetricName(MetricIdentifier(Identifier))
+
+# Parsing single function
+
+deg()
+
+==>
+PromQL(Expr(FunctionCall(FunctionIdentifier(Deg), FunctionCallBody)))

--- a/test/test-promql.js
+++ b/test/test-promql.js
@@ -1,5 +1,5 @@
 import {parser} from "../dist/index.es.js"
-import {fileTests} from "lezer-generator/dist/test"
+import {fileTests} from "./utils.js"
 
 import * as fs from "fs"
 import * as path from "path"

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,103 @@
+/**
+ * Turn a tree from the parser into a simple string format like PromQL(Expr(FunctionCall(...))) same as the way
+ * tests are written.
+ * @param tree
+ * @returns {string|undefined}
+ */
+export function treeToString(tree) {
+    let actual = ''
+    tree.iterate({
+        enter(type, start) {
+            if (!type.name) return
+            if (actual.length > 1 && actual.charAt(actual.length - 1) !== '(') {
+                // This is a case where we have sibling tokens so lets separate them,
+                actual += ', '
+            }
+            actual += type.name + '('
+            return undefined
+        },
+        leave(type, start) {
+            if (actual.charAt(actual.length - 1) === '(') {
+                // In case token is empty (no children) we don't want to render empty '()'
+                actual = actual.substring(0, actual.length - 1)
+            } else {
+                actual += ')'
+            }
+        }
+    })
+    return actual;
+}
+
+/**
+ * Returns a line context for the given file.
+ *
+ * @param {string} file
+ * @param {number} index
+ */
+function toLineContext(file, index) {
+    const endEol = file.indexOf('\n', index + 80);
+    const endIndex = endEol === -1 ? file.length : endEol;
+    return file.substring(index, endIndex).split(/\n/).map(str => '  | ' + str).join('\n');
+}
+
+export function fileTests(file, fileName) {
+    let caseExpr = /\s*#\s*(.*)(?:\r\n|\r|\n)([^]*?)==+>([^]*?)(?:$|(?:\r\n|\r|\n)+(?=#))/gy
+    let tests = []
+    let lastIndex = 0;
+    for (;;) {
+        let m = caseExpr.exec(file)
+        if (!m) throw new Error(`Unexpected file format in ${fileName} around\n\n${toLineContext(file, lastIndex)}`)
+
+        let [, name, configStr] = /(.*?)(\{.*?\})?$/.exec(m[1])
+        let config = configStr ? JSON.parse(configStr) : null
+
+        let text = m[2].trim(), expected = m[3].trim()
+        tests.push({
+            name,
+            run(parser) {
+                parser = parser.configure({strict: false, ...config})
+                const actual = treeToString(parser.parse(text))
+                const expectedNormalized = normalizeExpect(expected)
+
+                if (actual !== expectedNormalized) {
+                    const num = getDiffIndex(expectedNormalized, actual)
+                    let message = `\nExpected: ${expectedNormalized}`
+                    const prefixLength = 10
+                    message += '\n' + ' '.repeat(num + prefixLength) + '^'
+                    message += `\nActual:   ${actual}`
+                    throw new Error(message)
+                }
+            }
+        })
+        lastIndex = m.index + m[0].length
+        if (lastIndex == file.length) break
+    }
+    return tests
+}
+
+/**
+ * Do a normalization so the tests can be written in more readable form (like new lines and white space) and turn
+ * it into single line string which can be more easily compared with actual output.
+ * @param expected
+ * @returns {string}
+ */
+function normalizeExpect(expected) {
+    return expected.split('\n').map(s => s.trim()).join('').replace(/,(\S)/g,', $1')
+}
+
+/**
+ * Get the index at which strings starts to be different.
+ * @param s1
+ * @param s2
+ * @returns {number}
+ */
+function getDiffIndex(s1, s2) {
+    const length = Math.min(s1.length, s2.length)
+    let i = 0
+    for (;i < length; i++) {
+        if (s1.charAt(i) !== s2.charAt(i)) {
+            break
+        }
+    }
+    return i
+}


### PR DESCRIPTION
We use this parser in Grafana and we noticed some weird parsing that ended being just some missing functions definitions. I added those to the grammar file.

There are some other changes in the PR that I am not sure will be welcome or not and if yes then probably should be in separate PR but let me know.
- Changed the testing utils function. Before this used the utils from lezer library but there were a few weird decisions that made debugging changes and test failures pretty difficult. For one it was always strict unless the test was explicitly testing for error which meant I did not get any helpful info if there was some parsing error.
- Even when there wasn't a parsing error and there was just an actual expected diff it showed IMHO not so helpful message with very little context.

Current output when the test fails:
![Screenshot from 2022-02-23 16-47-08](https://user-images.githubusercontent.com/1014802/155356442-f23a2a52-955b-48a5-8447-5bd63b97492f.png)

So let me know if that makes sense as I said it's not important for the grammar changes and can either just delete them or move to separate PR.